### PR TITLE
Retain original LogonInfo object when overwriting credentials

### DIFF
--- a/Source/CrystalReportsNinja/ReportProcessor.cs
+++ b/Source/CrystalReportsNinja/ReportProcessor.cs
@@ -183,6 +183,7 @@ namespace CrystalReportsNinja
                 TableLogOnInfo logonInfo = new TableLogOnInfo();
                 foreach (Table table in _reportDoc.Database.Tables)
                 {
+                    logonInfo = table.LogOnInfo;
                     if (server != null)
                         logonInfo.ConnectionInfo.ServerName = server;
 


### PR DESCRIPTION
This fixes the issues with Report Error 208 where the data source in the report defines a schema/owner for the underlying data source but it doesn't get carried over when using this project and fails to run.  The way we were fixing this was moving all data sources into the default schema, but adding this line carries the existing information from the report over and allows for it to still be overwritten if needed. 

![image](https://user-images.githubusercontent.com/760989/111851965-a9a83f80-88eb-11eb-80dd-746391445203.png)

I believe this also fixes the problem defined in the Readme mentioned fully qualified table names etc. 

Also, I spent way too long trying to figure this out, until I stumbled upon the following documentation which shows an example doing this:
https://docs.microsoft.com/en-us/previous-versions/ms226184(v=vs.90)


