### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v1.0.2
+        
+      - name: Install CR
+        run: choco install crystalreports-for-vs --version=13.0.30.3805 --yes
+
+      - name: MSBuild
+        working-directory: Source
+        run: msbuild CrystalReportsNinja.sln /property:Configuration=Release
+
+      - name: List Outputs
+        working-directory: Source
+        run: dir
+    
+      - uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: Source/CrystalReportsNinja/bin/


### PR DESCRIPTION
In my other issue, you mentioned not having a build machine, so I figured I'd set up the free CI provided by GitHub to automatically build the binaries and provide artifacts as a binary. It's not perfected and should have an additional section for actually pushing out a release by tag, but this will allow for easy builds from master using the latest Crystal Reports version, and it will auto build on every push to master and any PR's that target master.

DISCLAIMER: This uses a chocolatey package to install the latest CR for Visual Studio in which I maintain and just released. It's not approved yet but can still be downloaded in the time being, so maybe wait to merge it until this shows as approved:

https://chocolatey.org/packages/crystalreports-for-vs/13.0.30.3805

There was another package on chocolatey that was outdated using a similar name, so I'm not sure the fate of the package I created.